### PR TITLE
Handle Teradata FORMAT column syntax

### DIFF
--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -225,7 +225,7 @@ class Teradata(Dialect):
             optional_parens: bool = True,
             any_token: bool = False,
         ) -> t.Optional[exp.Expression]:
-            # Teradata uses a `(FORMAT ...)` clause after column references to
+            # Teradata uses a `(FORMAT <format_string>)` clause after column references to
             # override the output format. When we see this pattern we do not
             # parse it as a function call.  The syntax is documented at
             # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Type-Formats-and-Format-Phrases/FORMAT
@@ -251,7 +251,7 @@ class Teradata(Dialect):
                 index = self._index
                 self._match(TokenType.L_PAREN)
                 if self._match(TokenType.FORMAT):
-                    # `(FORMAT ...)` after a column specifies a Teradata format
+                    # `(FORMAT <format_string>)` after a column specifies a Teradata format
                     # override. See
                     # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Type-Formats-and-Format-Phrases/FORMAT
                     fmt_string = self._parse_string()

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -252,9 +252,8 @@ class Teradata(Dialect):
                     if not self._match(TokenType.R_PAREN):
                         self.raise_error("Expecting )")
                     this = self.expression(
-                        exp.Cast,
+                        exp.FormatColumn,
                         this=this,
-                        to=exp.DataType.build(exp.DataType.Type.UNKNOWN),
                         format=fmt,
                     )
                 else:

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -225,6 +225,10 @@ class Teradata(Dialect):
             optional_parens: bool = True,
             any_token: bool = False,
         ) -> t.Optional[exp.Expression]:
+            # Teradata uses a `(FORMAT ...)` clause after column references to
+            # override the output format. When we see this pattern we do not
+            # parse it as a function call.  The syntax is documented at
+            # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Type-Formats-and-Format-Phrases/FORMAT
             if (
                 self._next
                 and self._next.token_type == TokenType.L_PAREN
@@ -247,6 +251,9 @@ class Teradata(Dialect):
                 index = self._index
                 self._match(TokenType.L_PAREN)
                 if self._match(TokenType.FORMAT):
+                    # `(FORMAT ...)` after a column specifies a Teradata format
+                    # override. See
+                    # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Type-Formats-and-Format-Phrases/FORMAT
                     fmt_string = self._parse_string()
                     fmt = self._parse_at_time_zone(fmt_string)
                     if not self._match(TokenType.R_PAREN):

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -218,6 +218,50 @@ class Teradata(Dialect):
                 self._retreat(self._index - 2)
             return this
 
+        def _parse_function(
+            self,
+            functions: t.Optional[t.Dict[str, t.Callable]] = None,
+            anonymous: bool = False,
+            optional_parens: bool = True,
+            any_token: bool = False,
+        ) -> t.Optional[exp.Expression]:
+            if (
+                self._next
+                and self._next.token_type == TokenType.L_PAREN
+                and self._index + 2 < len(self._tokens)
+                and self._tokens[self._index + 2].token_type == TokenType.FORMAT
+            ):
+                return None
+
+            return super()._parse_function(
+                functions=functions,
+                anonymous=anonymous,
+                optional_parens=optional_parens,
+                any_token=any_token,
+            )
+
+        def _parse_column_ops(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+            this = super()._parse_column_ops(this)
+
+            if self._match(TokenType.L_PAREN, advance=False):
+                index = self._index
+                self._match(TokenType.L_PAREN)
+                if self._match(TokenType.FORMAT):
+                    fmt_string = self._parse_string()
+                    fmt = self._parse_at_time_zone(fmt_string)
+                    if not self._match(TokenType.R_PAREN):
+                        self.raise_error("Expecting )")
+                    this = self.expression(
+                        exp.Cast,
+                        this=this,
+                        to=exp.DataType.build(exp.DataType.Type.UNKNOWN),
+                        format=fmt,
+                    )
+                else:
+                    self._retreat(index)
+
+            return this
+
     class Generator(generator.Generator):
         LIMIT_IS_TOP = True
         JOIN_HINTS = False

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5209,6 +5209,10 @@ class FromTimeZone(Expression):
     arg_types = {"this": True, "zone": True}
 
 
+class FormatColumn(Expression):
+    arg_types = {"this": True, "format": True}
+
+
 class Between(Predicate):
     arg_types = {"this": True, "low": True, "high": True}
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5210,6 +5210,14 @@ class FromTimeZone(Expression):
 
 
 class FormatColumn(Expression):
+    """Format override for a column in Teradata.
+
+    Teradata allows specifying a custom format string after a column using the
+    ``(FORMAT ...)`` clause as documented at
+    https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Type-Formats-and-Format-Phrases/FORMAT
+    .
+    """
+
     arg_types = {"this": True, "format": True}
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5210,12 +5210,10 @@ class FromTimeZone(Expression):
 
 
 class FormatColumn(Expression):
-    """Format override for a column in Teradata.
+    """Format override for a column in Teradata. 
+    Can be expanded to additional dialects as needed
 
-    Teradata allows specifying a custom format string after a column using the
-    ``(FORMAT ...)`` clause as documented at
     https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Type-Formats-and-Format-Phrases/FORMAT
-    .
     """
 
     arg_types = {"this": True, "format": True}

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3037,6 +3037,8 @@ class Generator(metaclass=_Generator):
         return f"{self.sql(expression, 'this')} FORMAT JSON"
 
     def formatcolumn_sql(self, expression: exp.FormatColumn) -> str:
+        # Output the Teradata column FORMAT override.
+        # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Type-Formats-and-Format-Phrases/FORMAT
         this = self.sql(expression, "this")
         fmt = self.sql(expression, "format")
         return f"{this} (FORMAT {fmt})"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3036,6 +3036,11 @@ class Generator(metaclass=_Generator):
     def formatjson_sql(self, expression: exp.FormatJson) -> str:
         return f"{self.sql(expression, 'this')} FORMAT JSON"
 
+    def formatcolumn_sql(self, expression: exp.FormatColumn) -> str:
+        this = self.sql(expression, "this")
+        fmt = self.sql(expression, "format")
+        return f"{this} (FORMAT {fmt})"
+
     def jsonobject_sql(self, expression: exp.JSONObject | exp.JSONObjectAgg) -> str:
         null_handling = expression.args.get("null_handling")
         null_handling = f" {null_handling}" if null_handling else ""

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -232,10 +232,7 @@ class TestTeradata(Validator):
         )
 
     def test_format_override(self):
-        self.validate_identity(
-            "SELECT Col1 (FORMAT '+9999') FROM Test1",
-            "SELECT CAST(Col1 AS FORMAT '+9999') FROM Test1",
-        )
+        self.validate_identity("SELECT Col1 (FORMAT '+9999') FROM Test1")
         self.validate_identity(
             "SELECT CAST(Col1 AS INTEGER) FROM Test1",
             "SELECT CAST(Col1 AS INT) FROM Test1",

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -231,6 +231,16 @@ class TestTeradata(Validator):
             },
         )
 
+    def test_format_override(self):
+        self.validate_identity(
+            "SELECT Col1 (FORMAT '+9999') FROM Test1",
+            "SELECT CAST(Col1 AS FORMAT '+9999') FROM Test1",
+        )
+        self.validate_identity(
+            "SELECT CAST(Col1 AS INTEGER) FROM Test1",
+            "SELECT CAST(Col1 AS INT) FROM Test1",
+        )
+
     def test_time(self):
         self.validate_identity("CAST(CURRENT_TIMESTAMP(6) AS TIMESTAMP WITH TIME ZONE)")
 

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -233,6 +233,7 @@ class TestTeradata(Validator):
 
     def test_format_override(self):
         self.validate_identity("SELECT Col1 (FORMAT '+9999') FROM Test1")
+        self.validate_identity("SELECT date_col (FORMAT 'YYYY-MM-DD') FROM t")
         self.validate_identity(
             "SELECT CAST(Col1 AS INTEGER) FROM Test1",
             "SELECT CAST(Col1 AS INT) FROM Test1",

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -232,7 +232,7 @@ class TestTeradata(Validator):
         )
 
     def test_format_override(self):
-        # Teradata column format overrides use the `(FORMAT ...)` syntax.
+        # Teradata column format overrides use the `(FORMAT <format_string>)` syntax.
         # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Type-Formats-and-Format-Phrases/FORMAT
         self.validate_identity("SELECT Col1 (FORMAT '+9999') FROM Test1")
         self.validate_identity("SELECT date_col (FORMAT 'YYYY-MM-DD') FROM t")

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -232,6 +232,8 @@ class TestTeradata(Validator):
         )
 
     def test_format_override(self):
+        # Teradata column format overrides use the `(FORMAT ...)` syntax.
+        # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Type-Formats-and-Format-Phrases/FORMAT
         self.validate_identity("SELECT Col1 (FORMAT '+9999') FROM Test1")
         self.validate_identity("SELECT date_col (FORMAT 'YYYY-MM-DD') FROM t")
         self.validate_identity(


### PR DESCRIPTION
## Summary
- support Teradata column format syntax `(FORMAT '<pattern>')`
- ensure identifiers followed by `(FORMAT` are not parsed as function calls
- test column FORMAT override parsing

## Testing
- `pre-commit run --files sqlglot/dialects/teradata.py tests/dialects/test_teradata.py`
- `make unit`

------
https://chatgpt.com/codex/tasks/task_e_6865307d3534832ab3f0c51156e29cbf